### PR TITLE
Update macro names to current version of Relic

### DIFF
--- a/malicious/malicious.h
+++ b/malicious/malicious.h
@@ -39,7 +39,7 @@ class Malicious2PC { public:
 	bn_t * s, *t;
 	eb_t *C, *D, g1, h1;
 	bn_t bn_r;
-	eb_t g1Tbl[EB_TABLE_MAX];
+	eb_t g1Tbl[RELIC_EB_TABLE_MAX];
 	Malicious2PC(NetIO * io, int party, int n1, int _n2, int n3) {
 		initialize_relic();
 		this->n1 = n1;
@@ -153,7 +153,7 @@ class Malicious2PC { public:
 	}
 	void setupAlice() {
 		eb_t h,tmp;
-		eb_t hTbl[EB_TABLE_MAX];
+		eb_t hTbl[RELIC_EB_TABLE_MAX];
 		io->recv_eb(&h, 1);
 		eb_mul_pre(hTbl, h);
 		prg.random_block(&Delta, 1);
@@ -220,7 +220,7 @@ class Malicious2PC { public:
 		prg.random_bn(w);
 		bn_mod(w,w,q);
 		eb_mul_fix_norm(h, gTbl, w);
-		eb_t hTbl[EB_TABLE_MAX];
+		eb_t hTbl[RELIC_EB_TABLE_MAX];
 		io->send_eb(&h, 1);
 		eb_mul_pre(hTbl, h);
 		block * bl = new block[ssp+2*ot->l];
@@ -756,7 +756,7 @@ class Malicious2PC { public:
 
 	void recoverAlice() {
 		eb_t tmp;
-		eb_t h1Tbl[EB_TABLE_MAX];
+		eb_t h1Tbl[RELIC_EB_TABLE_MAX];
 		io->recv_eb(&h1, 1);
 		io->send_block(&Delta, 1);
 		io->send_block(Delta_ib, n3);
@@ -783,7 +783,7 @@ class Malicious2PC { public:
 		io->recv_block(&Delta, 1);
 		PRG prg_tmp(&Delta);
 		prg_tmp.random_eb(&Delta_eb);
-		eb_t h1Tbl[EB_TABLE_MAX];
+		eb_t h1Tbl[RELIC_EB_TABLE_MAX];
 		eb_sub_norm(h1,h1,Delta_eb);
 		eb_mul_pre(h1Tbl, h1);
 


### PR DESCRIPTION
The constant `EB_TABLE_MAX` was renamed to `RELIC_EB_TABLE_MAX` in commit
[200a7a7304169b0ea71dffde69d6d768b5dcd6d4](https://github.com/relic-toolkit/relic/commit/200a7a7304169b0ea71dffde69d6d768b5dcd6d4).